### PR TITLE
fix: Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/envz/env_uint.go
+++ b/envz/env_uint.go
@@ -2,10 +2,12 @@ package envz
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
-	"math"
 )
+
+var testMaxUintOutOfRange = false
 
 func Uint(key string) (uint, error) {
 	env, found := os.LookupEnv(key)
@@ -18,8 +20,8 @@ func Uint(key string) (uint, error) {
 		return 0, fmt.Errorf("strconv.ParseInt: %w", err)
 	}
 
-	if value > math.MaxUint {
-		return 0, fmt.Errorf("value exceeds maximum uint value")
+	if value > math.MaxUint || testMaxUintOutOfRange {
+		return 0, fmt.Errorf("%s=%s: %w", key, env, ErrRange)
 	}
 
 	return uint(value), nil

--- a/envz/env_uint.go
+++ b/envz/env_uint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"math"
 )
 
 func Uint(key string) (uint, error) {
@@ -15,6 +16,10 @@ func Uint(key string) (uint, error) {
 	value, err := strconv.ParseUint(env, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("strconv.ParseInt: %w", err)
+	}
+
+	if value > math.MaxUint {
+		return 0, fmt.Errorf("value exceeds maximum uint value")
 	}
 
 	return uint(value), nil

--- a/envz/env_uint.go
+++ b/envz/env_uint.go
@@ -7,7 +7,10 @@ import (
 	"strconv"
 )
 
-var testMaxUintOutOfRange = false
+//nolint:gochecknoglobals // for test
+var (
+	testMaxUintOutOfRange = false
+)
 
 func Uint(key string) (uint, error) {
 	env, found := os.LookupEnv(key)

--- a/envz/env_uint_test.go
+++ b/envz/env_uint_test.go
@@ -2,6 +2,7 @@
 package envz
 
 import (
+	"math"
 	"strconv"
 	"testing"
 )
@@ -33,6 +34,21 @@ func TestUint(t *testing.T) {
 	t.Run("failure(fail-to-format)", func(t *testing.T) {
 		const expect = 0
 		t.Setenv(TEST_ENV_KEY, "test string")
+		actual, err := Uint(TEST_ENV_KEY)
+		if err == nil {
+			t.Errorf("❌: Env: err == nil")
+		}
+		if expect != actual {
+			t.Errorf("❌: expect != actual: %v != %v", expect, actual)
+		}
+	})
+
+	t.Run("failure(value-exceeds-maximum-uint-value)", func(t *testing.T) {
+		const expect = 0
+		t.Setenv(TEST_ENV_KEY, strconv.FormatUint(math.MaxUint, 10))
+		backup := testMaxUintOutOfRange
+		t.Cleanup(func() { testMaxUintOutOfRange = backup })
+		testMaxUintOutOfRange = true
 		actual, err := Uint(TEST_ENV_KEY)
 		if err == nil {
 			t.Errorf("❌: Env: err == nil")

--- a/envz/errors.go
+++ b/envz/errors.go
@@ -1,8 +1,12 @@
 package envz
 
-import "errors"
+import (
+	"errors"
+	"strconv"
+)
 
 var (
+	ErrRange                               = errors.New(strconv.ErrRange.Error())
 	ErrEnvironmentVariableIsEmpty          = errors.New("environment variable is empty")
 	ErrInvalidType                         = errors.New("invalid type; must be a pointer to a struct")
 	ErrStructFieldCannotBeSet              = errors.New("struct field cannot be set; unexported field or field is not settable")


### PR DESCRIPTION
Potential fix for [https://github.com/hakadoriya/z.go/security/code-scanning/2](https://github.com/hakadoriya/z.go/security/code-scanning/2)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseUint` fits within the bounds of the `uint` type before performing the conversion. This can be done by checking if the parsed value is within the range of the `uint` type and returning an error if it is not.

The best way to fix the problem is to add a bounds check for the `uint` type before converting the parsed value. We will use the `math` package to get the maximum value for the `uint` type and compare the parsed value against this maximum.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
