### PR TITLE
fix: Update .github/dependabot.yml for https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       - "ci"
     assignees:
       - "hakadoriya/owner"
-    reviewers:
-      - "hakadoriya/owner"
     groups:
       dependencies:
         patterns:
@@ -33,8 +31,6 @@ updates:
     labels:
       - "build"
     assignees:
-      - "hakadoriya/owner"
-    reviewers:
       - "hakadoriya/owner"
     groups:
       dependencies:
@@ -54,8 +50,6 @@ updates:
       - "build"
     assignees:
       - "hakadoriya/owner"
-    reviewers:
-      - "hakadoriya/owner"
     groups:
       dependencies:
         patterns:
@@ -74,8 +68,6 @@ updates:
       - "build"
     assignees:
       - "hakadoriya/owner"
-    reviewers:
-      - "hakadoriya/owner"
     groups:
       dependencies:
         patterns:
@@ -93,8 +85,6 @@ updates:
     labels:
       - "build"
     assignees:
-      - "hakadoriya/owner"
-    reviewers:
       - "hakadoriya/owner"
     groups:
       dependencies:


### PR DESCRIPTION
<!-- markdownlint-disable MD004 MD041 -->

## Ticket / Issue Number

> **Note**
> *Please fill in the ticket or issue number.*
> > Example:
> >
> > #1

## What's changed

> **Note**
> *Please explain what changes this pull request will make.*
> > Example:
> >
> > - Added functionality to perform 'bar' on 'foo'.

## Check List

- [x] Assign labels
- [x] Assign reviewers
- [x] Assign assignees
- [x] Add appropriate test cases

## Remark

> **Note**
> *Please provide additional remarks if necessary.*

<!-- markdownlint-enable MD004 MD041 -->
